### PR TITLE
Fix duplicated item

### DIFF
--- a/CRA9_F5/EmpManager/EmpManagerTest/EmpManagerTest.vcxproj.filters
+++ b/CRA9_F5/EmpManager/EmpManagerTest/EmpManagerTest.vcxproj.filters
@@ -52,6 +52,5 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="packages.config" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
package.config가 중복으로 적혀있어 vs studio에서 제대로 안 열리는 문제 해결