### PR TITLE
Feature 상세출력을 위해, 정렬된 employee 벡터 (최대 크기 5)를 리턴하는 함수 정의 및 구현

### DIFF
--- a/CRA9_F5/EmpManager/EmpManager/CommandResult.h
+++ b/CRA9_F5/EmpManager/EmpManager/CommandResult.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <iostream>
 #include <vector>
+#include <algorithm>
 #include "Employ.h"
 
 using namespace std;
@@ -33,7 +34,22 @@ public:
 	vector<Employ> getDetailResults() {
 		vector<Employ> result;
 		result.reserve(5);
-		// TODO!! TODO!!
+		sort(list.begin(), list.end(), [this](Employ a, Employ b) {
+			return MakeFullEmployeeNum(a.getEmployeeNum()) < MakeFullEmployeeNum(b.getEmployeeNum());
+		});
+		for (auto employee : list) {
+			result.push_back(employee);
+			if (result.size() >= 5)
+				return result;
+		}
 		return result;
 	}
+
+	int MakeFullEmployeeNum(int partial_EmployNum) {
+		if (partial_EmployNum < 69000000) {
+			return partial_EmployNum + 2000000000;
+		}
+		return partial_EmployNum + 1900000000;
+	}
 };
+

--- a/CRA9_F5/EmpManager/EmpManager/CommandResult.h
+++ b/CRA9_F5/EmpManager/EmpManager/CommandResult.h
@@ -29,4 +29,11 @@ public:
 	string getSimpleResults() {
 		return count == 0 ? string("NONE") : to_string(count);
 	}
+
+	vector<Employ> getDetailResults() {
+		vector<Employ> result;
+		result.reserve(5);
+		// TODO!! TODO!!
+		return result;
+	}
 };

--- a/CRA9_F5/EmpManager/EmpManager/Employ.h
+++ b/CRA9_F5/EmpManager/EmpManager/Employ.h
@@ -44,6 +44,12 @@ public:
 	bool operator!=(PhoneNumber p) const {
 		return !(*this == p);
 	}
+	PhoneNumber& operator=(const PhoneNumber& p) {
+		phoneNumber[FIRST] = p.phoneNumber[FIRST];
+		phoneNumber[MIDDLE] = p.phoneNumber[MIDDLE];
+		phoneNumber[LAST] = p.phoneNumber[LAST];
+		return *this;
+	}
 
 private:
 	enum {
@@ -85,6 +91,12 @@ public:
 	}
 	bool operator!=(Birthday b) const {
 		return !(*this==b);
+	}
+	Birthday& operator=(const Birthday& b) {
+		year = b.year;
+		month = b.month;
+		day = b.day;
+		return *this;
 	}
 
 private:
@@ -128,6 +140,11 @@ public:
 	}
 	bool operator!=(Name n) const {
 		return !(*this == n);
+	}
+	Name operator=(const Name& n) {
+		name[FIRST] = n.name[FIRST];
+		name[LAST] = n.name[LAST];
+		return *this;
 	}
 
 private:
@@ -199,6 +216,16 @@ public:
 	}
 	bool operator!=(Employ e) const{
 		return !(*this == e);
+	}
+	Employ& operator=(Employ e) {
+		employeeNum = e.employeeNum;
+		name = e.name;
+		cl = e.cl;
+		phoneNum = e.phoneNum;
+		birthday = e.birthday;
+		certi = e.certi;
+
+		return *this;
 	}
 
 private:

--- a/CRA9_F5/EmpManager/EmpManagerTest/CommandProcessorTest_Fixture.cpp
+++ b/CRA9_F5/EmpManager/EmpManagerTest/CommandProcessorTest_Fixture.cpp
@@ -400,3 +400,69 @@ TEST_F(CommandProcessorFixture, DELTest3) {
 	CommandResult CR_exp = CommandResult((int)list_result.size(), list_result);
 	EXPECT_EQ(CR, CR_exp);
 }
+
+
+TEST_F(CommandProcessorFixture, DELgreaterthan5) {
+	//set env
+	CommandProcessorADD<MockDatabase> cmdADD = CommandProcessorADD<MockDatabase>();
+	vector<enumOptionList> input_option = { enumOptionList::None, enumOptionList::None, enumOptionList::None };
+	vector<string> input_empVecStr1 = { "15123099","VXIHXOTH JHOP","CL3","010-3112-2609","19771211","ADV" };
+	vector<string> input_empVecStr2 = { "17112609", "FB NTAWR", "CL4", "010-5645-6122", "19861203", "PRO" };
+	vector<string> input_empVecStr3 = { "18115040", "TTETHU HBO", "CL3", "010-4581-2050", "20080718", "ADV" };
+	vector<string> input_empVecStr4 = { "88114052", "NQ LVARW", "CL4", "010-4528-3059", "20080718", "PRO" };
+	vector<string> input_empVecStr5 = { "99115601","VXIHXOTH JHOP","CL4","010-1234-5678","20080718","EX" };
+	vector<string> input_empVecStr6 = { "16678201","VXIHXOTH HBO","CL4","010-1234-5678","20080718","PRO" };
+	vector<string> input_empVecStr7 = { "12625901","LVARW JHOP","CL4","010-1234-5678","20080718","PRO" };
+	vector<string> input_empVecStr8 = { "06688301","NTAWR JHOP","CL4","010-1234-5678","20080718","EX" };
+
+	EXPECT_CALL(MockDatabase::getInstance(), insertItem(_)).
+		Times(8).
+		WillRepeatedly(Return(true));
+	CommandResult CR;
+	CR = cmdADD.run(input_option, input_empVecStr1);
+	ASSERT_EQ(CR.count, 1);
+	CR = cmdADD.run(input_option, input_empVecStr2);
+	ASSERT_EQ(CR.count, 1);
+	CR = cmdADD.run(input_option, input_empVecStr3);
+	ASSERT_EQ(CR.count, 1);
+	CR = cmdADD.run(input_option, input_empVecStr4);
+	ASSERT_EQ(CR.count, 1);
+	CR = cmdADD.run(input_option, input_empVecStr5);
+	ASSERT_EQ(CR.count, 1);
+	CR = cmdADD.run(input_option, input_empVecStr6);
+	ASSERT_EQ(CR.count, 1);
+	CR = cmdADD.run(input_option, input_empVecStr7);
+	ASSERT_EQ(CR.count, 1);
+	CR = cmdADD.run(input_option, input_empVecStr8);
+	ASSERT_EQ(CR.count, 1);
+
+	//DELgreaterthan5
+	CommandProcessorDEL<MockDatabase> cmdDEL = CommandProcessorDEL<MockDatabase>();
+	vector<Employ> sorted_result;
+	sorted_result.push_back(Employ(input_empVecStr4));
+	sorted_result.push_back(Employ(input_empVecStr5));
+	sorted_result.push_back(Employ(input_empVecStr8));
+	sorted_result.push_back(Employ(input_empVecStr7));
+	sorted_result.push_back(Employ(input_empVecStr6));
+
+	vector<Employ> raw_result;
+	raw_result.push_back(Employ(input_empVecStr3));
+	raw_result.push_back(Employ(input_empVecStr4));
+	raw_result.push_back(Employ(input_empVecStr5));
+	raw_result.push_back(Employ(input_empVecStr6));
+	raw_result.push_back(Employ(input_empVecStr7));
+	raw_result.push_back(Employ(input_empVecStr8));
+
+	EXPECT_CALL(MockDatabase::getInstance(), deleteItems(_, _)).
+		Times(1).
+		WillOnce(Return(raw_result));
+
+	CR = cmdDEL.run(input_option, { "birthday", "20080718" });
+	CommandResult CR_exp = CommandResult((int)sorted_result.size(), sorted_result);
+	vector<Employ> CR_sorted = CR.getDetailResults();
+	ASSERT_EQ(CR_sorted.size(), CR_exp.list.size());
+
+	for (int i = 0; i < CR_exp.list.size(); ++i) {
+		EXPECT_EQ(CR_sorted[i], CR_exp.list[i]);
+	}
+}


### PR DESCRIPTION
- 상세출력을 위해, 정렬된 employee 벡터 (최대 크기 5)를 리턴하는 함수의 interface 정의
- 테스트 코드 추가
- getDetailResult 구현 (operator= 재정의)
- #36 중 operator= 재정의와 충돌이 발생하므로 manually conflict 해결 필요 (진행 예정)