### PR TITLE
[Refactor] commandProcessor를 EmployManager 생성자에서 생성

### DIFF
--- a/CRA9_F5/EmpManager/EmpManager/employManager.cpp
+++ b/CRA9_F5/EmpManager/EmpManager/employManager.cpp
@@ -9,16 +9,7 @@ CommandProcessor* EmployManager::getProcessor(enumCommandList cmd) {
 }
 #else
 CommandProcessor* EmployManager::getProcessor(enumCommandList cmd) {
-	switch (cmd) {
-	case enumCommandList::ADD:
-		return  new CommandProcessorADD<DatabaseInterface>();
-	case enumCommandList::DEL:
-		return  new CommandProcessorDEL<DatabaseInterface>();
-	case enumCommandList::MOD:
-		return  new CommandProcessorMOD<DatabaseInterface>();
-	case enumCommandList::SCH:
-		return new CommandProcessorSCH<DatabaseInterface>();
-	}
+	return cmdProcessorArr.find(cmd)->second;
 }
 #endif
 

--- a/CRA9_F5/EmpManager/EmpManager/employManager.h
+++ b/CRA9_F5/EmpManager/EmpManager/employManager.h
@@ -26,14 +26,22 @@ private:
 	CommandProcessor* cmdProcessor;
 	CommandResult cmdResult;
 
+	map<enumCommandList, CommandProcessor*> cmdProcessorArr;
+
 	vector<string> cmdList = { "ADD", "DEL", "SCH", "MOD" };
 	vector<string> clList = { "NONE", "CL1", "CL2", "CL3", "CL4" };
 	vector<string> certiList = { "ADV", "PRO", "EX" };
 
-
 	CommandProcessor* getProcessor(enumCommandList cmd);
 	string empNumTostr(int employNum);
 public:
+	EmployManager(){
+		cmdProcessorArr[enumCommandList::ADD] = new CommandProcessorADD<DatabaseInterface>();
+		cmdProcessorArr[enumCommandList::DEL] = new CommandProcessorDEL<DatabaseInterface>();
+		cmdProcessorArr[enumCommandList::MOD] = new CommandProcessorMOD<DatabaseInterface>();
+		cmdProcessorArr[enumCommandList::SCH] = new CommandProcessorSCH<DatabaseInterface>();
+	}
+
 	vector<string> runCommand(string input);
 	vector<string> cmdResultTostrList(enumCommandList cmd, CommandResult cmdResult);
 };


### PR DESCRIPTION
- commandProcessor를 enumComandList 를 Key로 commandProcessor* 를 value로 가지는 map 형태로
관리하고, EmployManager 생성자에서 초기화 하는 작업 추가